### PR TITLE
Import React and React.Component from the react module instead of react-native

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,14 +7,13 @@
 
 'use strict'
 
-var React = require('react-native');
-var {
+import React, { Component } from 'react'
+import {
   StyleSheet,
   View,
   Text,
-  Component,
   TouchableOpacity,
-} = React;
+} from 'react-native'
 
 class CircleCheckBox extends Component {
 


### PR DESCRIPTION
Inclusion of React from react-native itself has been deprecated
